### PR TITLE
Fixed work with opensuse i586 iso

### DIFF
--- a/daemon/guestfsd.c
+++ b/daemon/guestfsd.c
@@ -663,9 +663,9 @@ compare_device_names (const char *a, const char *b)
   if (STRPREFIX (b, "/dev/"))
     b += 5;
 
-  /* Skip sd/hd/ubd/vd. */
-  alen = strcspn (a, "d");
-  blen = strcspn (b, "d");
+  /* Skip sd/hd/ubd/vd/sr. */
+  alen = strcspn (a, "dr");
+  blen = strcspn (b, "dr");
   assert (alen > 0 && alen <= 2);
   assert (blen > 0 && blen <= 2);
   a += alen + 1;

--- a/generator/actions_core.ml
+++ b/generator/actions_core.ml
@@ -435,7 +435,7 @@ not all belong to a single logical operating system
 
   { defaults with
     name = "add_drive"; added = (0, 0, 3);
-    style = RErr, [String "filename"], [OBool "readonly"; OString "format"; OString "iface"; OString "name"; OString "label"; OString "protocol"; OStringList "server"; OString "username"; OString "secret"; OString "cachemode"; OString "discard"; OBool "copyonread"];
+    style = RErr, [String "filename"], [OBool "readonly"; OString "format"; OString "iface"; OString "name"; OString "label"; OString "protocol"; OStringList "server"; OString "username"; OString "secret"; OString "cachemode"; OString "discard"; OBool "copyonread"; OString "device"];
     once_had_no_optargs = true;
     blocking = false;
     fish_alias = ["add"];

--- a/lib/drives.c
+++ b/lib/drives.c
@@ -58,6 +58,7 @@ struct drive_create_data {
   const char *cachemode;
   enum discard discard;
   bool copyonread;
+  enum device device;
 };
 
 COMPILE_REGEXP (re_hostname_port, "(.*):(\\d+)$", 0)
@@ -114,6 +115,7 @@ create_drive_file (guestfs_h *g,
   drv->cachemode = data->cachemode ? safe_strdup (g, data->cachemode) : NULL;
   drv->discard = data->discard;
   drv->copyonread = data->copyonread;
+  drv->device = data->device;
 
   if (data->readonly) {
     if (create_overlay (g, drv) == -1) {
@@ -436,6 +438,7 @@ create_drive_dev_null (guestfs_h *g,
   data->exportname = tmpfile;
   data->discard = discard_disable;
   data->copyonread = false;
+  data->device = device_disk;
 
   return create_drive_file (g, data);
 }
@@ -762,6 +765,17 @@ guestfs_impl_add_drive_opts (guestfs_h *g, const char *filename,
   }
   else
     data.discard = discard_disable;
+
+  if (optargs->bitmask & GUESTFS_ADD_DRIVE_OPTS_DEVICE_BITMASK) {
+    if (STREQ (optargs->device, "disk")) {
+        data.device = device_disk;
+    }
+    if (STREQ (optargs->device, "cdrom")) {
+        data.device = device_cdrom;
+    }
+  }
+  else
+      data.device = device_disk;
 
   data.copyonread =
     optargs->bitmask & GUESTFS_ADD_DRIVE_OPTS_COPYONREAD_BITMASK

--- a/lib/drives.c
+++ b/lib/drives.c
@@ -58,7 +58,7 @@ struct drive_create_data {
   const char *cachemode;
   enum discard discard;
   bool copyonread;
-  enum device device;
+  enum device_type device;
 };
 
 COMPILE_REGEXP (re_hostname_port, "(.*):(\\d+)$", 0)
@@ -770,12 +770,18 @@ guestfs_impl_add_drive_opts (guestfs_h *g, const char *filename,
     if (STREQ (optargs->device, "disk")) {
         data.device = device_disk;
     }
-    if (STREQ (optargs->device, "cdrom")) {
+    else if (STREQ (optargs->device, "cdrom")) {
         data.device = device_cdrom;
     }
+    else {
+        error (g, _("device parameter must be 'disk' or 'cdrom'"));
+        free_drive_servers (data.servers, data.nr_servers);
+        return -1;
+    }
   }
-  else
+  else {
       data.device = device_disk;
+  }
 
   data.copyonread =
     optargs->bitmask & GUESTFS_ADD_DRIVE_OPTS_COPYONREAD_BITMASK

--- a/lib/guestfs-internal.h
+++ b/lib/guestfs-internal.h
@@ -257,6 +257,11 @@ enum discard {
   discard_besteffort,
 };
 
+enum device {
+  device_disk = 0,
+  device_cdrom,
+};
+
 /**
  * There is one C<struct drive> per drive, including hot-plugged drives.
  */
@@ -282,6 +287,7 @@ struct drive {
   char *cachemode;
   enum discard discard;
   bool copyonread;
+  enum device device;
 };
 
 /* Extra hv parameters (from guestfs_config). */

--- a/lib/guestfs-internal.h
+++ b/lib/guestfs-internal.h
@@ -257,7 +257,7 @@ enum discard {
   discard_besteffort,
 };
 
-enum device {
+enum device_type {
   device_disk = 0,
   device_cdrom,
 };
@@ -287,7 +287,7 @@ struct drive {
   char *cachemode;
   enum discard discard;
   bool copyonread;
-  enum device device;
+  enum device_type device;
 };
 
 /* Extra hv parameters (from guestfs_config). */

--- a/lib/launch-direct.c
+++ b/lib/launch-direct.c
@@ -575,7 +575,12 @@ launch_direct (guestfs_h *g, void *datav, const char *arg)
       ADD_CMDLINE ("-drive");
       ADD_CMDLINE_PRINTF ("%s,if=none" /* sic */, param);
       ADD_CMDLINE ("-device");
-      ADD_CMDLINE_PRINTF ("scsi-hd,drive=hd%zu", i);
+      if (drv->device == device_cdrom) {
+        ADD_CMDLINE_PRINTF ("scsi-cd,drive=hd%zu", i);
+      }
+      else {
+        ADD_CMDLINE_PRINTF ("scsi-hd,drive=hd%zu", i);
+      }
     }
     else {
     virtio_blk:
@@ -927,13 +932,15 @@ make_appliance_dev (guestfs_h *g, int virtio_scsi)
 
   /* Calculate the index of the drive. */
   ITER_DRIVES (g, i, drv) {
-    if (virtio_scsi) {
-      if (drv->iface == NULL || STREQ (drv->iface, "ide"))
-        index++;
-    }
-    else /* virtio-blk */ {
-      if (drv->iface == NULL || STRNEQ (drv->iface, "virtio"))
-        index++;
+    if (drv->device == device_disk) {
+      if (virtio_scsi) {
+        if (drv->iface == NULL || STREQ (drv->iface, "ide"))
+          index++;
+      }
+      else /* virtio-blk */ {
+        if (drv->iface == NULL || STRNEQ (drv->iface, "virtio"))
+          index++;
+      }
     }
   }
 

--- a/lib/launch-direct.c
+++ b/lib/launch-direct.c
@@ -578,7 +578,7 @@ launch_direct (guestfs_h *g, void *datav, const char *arg)
       if (drv->device == device_cdrom) {
         ADD_CMDLINE_PRINTF ("scsi-cd,drive=hd%zu", i);
       }
-      else {
+      else if (drv->device == device_disk) {
         ADD_CMDLINE_PRINTF ("scsi-hd,drive=hd%zu", i);
       }
     }
@@ -934,12 +934,14 @@ make_appliance_dev (guestfs_h *g, int virtio_scsi)
   ITER_DRIVES (g, i, drv) {
     if (drv->device == device_disk) {
       if (virtio_scsi) {
-        if (drv->iface == NULL || STREQ (drv->iface, "ide"))
+        if (drv->iface == NULL || STREQ (drv->iface, "ide")) {
           index++;
+        }
       }
       else /* virtio-blk */ {
-        if (drv->iface == NULL || STRNEQ (drv->iface, "virtio"))
+        if (drv->iface == NULL || STRNEQ (drv->iface, "virtio")) {
           index++;
+        }
       }
     }
   }


### PR DESCRIPTION
Added parsing device value in xml and implemented using "scsi-cd" except "scsi-hd" for qemu command in device=cdrom case.